### PR TITLE
Add True Alarm Functionality to the SnoozeAlarm Class

### DIFF
--- a/utility/SnoozeAlarm.cpp
+++ b/utility/SnoozeAlarm.cpp
@@ -20,7 +20,8 @@ time_t rtc_set_sync_provider( void ) {
 }
 
 /*******************************************************************************
- *  <#Description#>
+ *  <#Description#> Sets an alarm for a specific amount of time once the driver
+ *                  is enabled. Is dependent of when the driver is enabled.
  *
  *  @param hours   <#hours description#>
  *  @param minutes <#minutes description#>
@@ -29,6 +30,20 @@ time_t rtc_set_sync_provider( void ) {
 void SnoozeAlarm::setAlarm(  uint8_t hours, uint8_t minutes, uint8_t seconds ) {
     isUsed = true;
     alarm = hours*3600 + minutes*60 + seconds;
+    timer_ = true;
+}
+
+/*******************************************************************************
+ *  <#Description#> Override of original setAlarm function. Works more like a
+ *                  standard alarm. Is independent of when the driver is enabled.
+ *                  (So long as it is enabled before the alarmTime)
+ *
+ *  @param alarmTime <#time_t number of specific date & time to set alarm#>
+ *******************************************************************************/
+void SnoozeAlarm::setAlarm( time_t alarmTime){
+    isUsed = true;
+    alarm = alarmTime;
+    timer_ = false;
 }
 
 /*******************************************************************************
@@ -76,7 +91,10 @@ void SnoozeAlarm::enableDriver( void ) {
     }
     
     IER = RTC_IER;
-    RTC_TAR = rtc_get( ) + ( alarm - 1 );
+    if(timer_) // If setting timer style alarm
+        RTC_TAR = rtc_get( ) + ( alarm - 1 );
+    else        // else, setting true alarm
+        RTC_TAR = alarm - 1;
     RTC_IER = RTC_IER_TAIE_MASK;
 }
 

--- a/utility/SnoozeAlarm.h
+++ b/utility/SnoozeAlarm.h
@@ -46,6 +46,7 @@ private:
     uint32_t TAR;
     uint32_t IER;
     bool SIM_SCGC6_clock_active;
+    bool timer_;
 public:
     SnoozeAlarm( void ) : TAR( false ), IER( false ),
                         SIM_SCGC6_clock_active( false )
@@ -53,5 +54,6 @@ public:
         isDriver = true;
     }
     void setAlarm( uint8_t hours, uint8_t minutes, uint8_t seconds );
+    void setAlarm( time_t alarmTime);
 };
 #endif /* defined(SnoozeAlarm_h) */


### PR DESCRIPTION
With a few lines of modified code, the SnoozeAlarm class can be much more functional. I've added the ability to set an alarm for a specific date and time, rather than an amount of time after the driver is enabled.  It still keeps the functionality of the timer version of setAlarm, and overloads the function to take a time_t number and modifies the boolean timer_ variable to be false. When the alarm is enabled, the program checks the value of timer_ to decide what to assign RTC_TAR to.