### PR TITLE
Reduced Block UART example - fix for Teensy LC at low power

### DIFF
--- a/examples/reduced_cpu_block/HardwareSerial/HardwareSerial1_LP.h
+++ b/examples/reduced_cpu_block/HardwareSerial/HardwareSerial1_LP.h
@@ -4,8 +4,16 @@
 //  and back to F_CPU.
 //
 
+#if defined(HAS_KINETISK_UART0)
 #define BAUD2DIV_2MHZ(baud) (((TWO_MHZ * 2) + ((baud) >> 1)) / (baud))
-#define BAUD2DIV(baud) (((F_CPU * 2) + ((baud) >> 1)) / (baud))
+#elif defined(HAS_KINETISL_UART0)
+// LC uses OSCERCLK, which is 16 MHz. Oversample rate is 4.
+#define BAUD2DIV_2MHZ(baud) (((SIXTEEN_MHZ / 4) + ((baud) >> 1)) / (baud))
+
+#define SIM_SOPT2_UART0SRC_MASK 0x0C000000
+#define UART0_C4_OSR_MASK 0x1F
+#define UART0_C4_OSR(n) (((n) & UART0_C4_OSR_MASK))  //  Oversample rate - 1
+#endif
 /***************************************************************************************************/
 // C language implementation
 //
@@ -36,11 +44,31 @@ class HardwareSerial1_LP : public SnoozeBlock {
 private:
     virtual void disableDriver( void ) {
         serial1_begin_lp( BAUD2DIV( baudRate ) );
+ 
+#if defined(HAS_KINETISL_UART0)
+        // Restore UART source and oversample rate (OSR)
+        SIM_SOPT2 = SIM_SOPT2 & ~SIM_SOPT2_UART0SRC_MASK | previousUARTSRC;
+        UART0_C4 = UART0_C4 & ~UART0_C4_OSR_MASK | previousOSR;
+#endif
     }
     virtual void enableDriver( void ) {
         serial1_begin_lp( BAUD2DIV_2MHZ( baudRate ) );
+
+#if defined(HAS_KINETISL_UART0)
+        // Save current values for restoring later
+        previousUARTSRC = SIM_SOPT2 & SIM_SOPT2_UART0SRC_MASK;
+        previousOSR = UART0_C4 & UART0_C4_OSR_MASK;
+        
+        // Change UART source to OSCERCLK
+        SIM_SOPT2 = SIM_SOPT2 & ~SIM_SOPT2_UART0SRC_MASK | SIM_SOPT2_UART0SRC(2);
+
+        // Set oversample rate (OSR) to 4 (value = 3 = n - 1)
+        UART0_C4 = UART0_C4 & ~UART0_C4_OSR_MASK | UART0_C4_OSR(3);
+#endif
     }
     uint32_t baudRate;
+    uint32_t previousUARTSRC;
+    uint32_t previousOSR;
 public:
     
     HardwareSerial1_LP( uint32_t baud ) : baudRate( baud ) {


### PR DESCRIPTION
Teensy LC UART0 doesn't use F_BUS, but uses F_PLL, which is stopped in low power mode. So this uses OSCERCLK instead, which is the 16 MHz crystal. It also changes oversampling from 16 to 4, so that baud divisor starts at 4 MHz instead of 1 MHz, to provide closer baud rates. Upon exiting the reduced block, it restores the original settings.