### PR TITLE
SnoozeBlock::next_block array used without being initialized

### DIFF
--- a/SnoozeBlock.h
+++ b/SnoozeBlock.h
@@ -167,7 +167,9 @@ public:
      *  @return nothing
      ***********************************************************************************/
     template<class ...Tail>
-    SnoozeBlock ( SnoozeBlock &head, Tail&... tail )  : local_block( -1 ), isUsed( false ), isDriver( false ) {
+    SnoozeBlock ( SnoozeBlock &head, Tail&... tail ) :
+			next_block { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr },
+			local_block( -1 ), isUsed( false ), isDriver( false ) {
         
         if ( mode < VLLS3 ) mode = RUN;
         // number of drivers left to connected to the Snooze Block
@@ -221,6 +223,7 @@ public:
      *  @return this
      ***********************************************************************************/
     SnoozeBlock ( void ) :
+                next_block { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr },
                 local_block( -1 ),
                 isUsed( false ),
                 isDriver( false )

--- a/SnoozeBlock.h
+++ b/SnoozeBlock.h
@@ -168,7 +168,7 @@ public:
      ***********************************************************************************/
     template<class ...Tail>
     SnoozeBlock ( SnoozeBlock &head, Tail&... tail ) :
-                next_block { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr },
+                next_block { nullptr, },
                 local_block( -1 ), isUsed( false ), isDriver( false )
         
         if ( mode < VLLS3 ) mode = RUN;
@@ -223,7 +223,7 @@ public:
      *  @return this
      ***********************************************************************************/
     SnoozeBlock ( void ) :
-                next_block { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr },
+                next_block { nullptr, },
                 local_block( -1 ),
                 isUsed( false ),
                 isDriver( false )

--- a/SnoozeBlock.h
+++ b/SnoozeBlock.h
@@ -168,8 +168,8 @@ public:
      ***********************************************************************************/
     template<class ...Tail>
     SnoozeBlock ( SnoozeBlock &head, Tail&... tail ) :
-			next_block { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr },
-			local_block( -1 ), isUsed( false ), isDriver( false ) {
+                next_block { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr },
+                local_block( -1 ), isUsed( false ), isDriver( false )
         
         if ( mode < VLLS3 ) mode = RUN;
         // number of drivers left to connected to the Snooze Block


### PR DESCRIPTION
The `SnoozeBlock::next_block` array is used without being initialized. When SnoozeBlock is statically initialized, this problem is masked by the fact that static (BSS segment) data is guaranteed to be initialized to zeros. If you attempt to instantiate a SnoozeBlock suite (drivers and configuration) dynamically, though, things go pear-shaped very quickly, as the constructor walks through what it thinks is a linked list of SnoozeBlock object pointers, but is in reality just random garbage.
Adding next_block to the initializer lists in the two constructors fixes the problem:
```
    template<class ...Tail>
    SnoozeBlock ( SnoozeBlock &head, Tail&... tail ) :
                next_block { nullptr, },
                local_block( -1 ), isUsed( false ), isDriver( false )
                { ... }

```