### PR TITLE
Fix TD1.56 / T40 startup problem

### DIFF
--- a/src/hal/TEENSY_40/hal.c
+++ b/src/hal/TEENSY_40/hal.c
@@ -649,6 +649,7 @@ void start_up( void ) {
      __asm__ volatile( "MOV PC, LR" );*/
 }
 //----------------------------------------------------------------------------------
+FLASHMEM
 void startup_early_hook( void ) {
     uint32_t OR_D_GPR = IOMUXC_GPR_GPR4 | IOMUXC_GPR_GPR7 | IOMUXC_GPR_GPR8 | IOMUXC_GPR_GPR12;
     if ( OR_D_GPR > 0x0 ) {


### PR DESCRIPTION
SInce 1.56, startup_early_hook() needs a FLASHMEM